### PR TITLE
add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: dataset
+title: "EDINET-Bench: Evaluating LLMs on Complex Financial Tasks using Japanese Financial Statements"
+authors:
+  - family-names: Sugiura
+    given-names: Issa
+  - family-names: Ishida
+    given-names: Takashi
+  - family-names: Makino
+    given-names: Taro
+  - family-names: Tazuke
+    given-names: Chieko
+  - family-names: Nakagawa
+    given-names: Takanori
+  - family-names: Nakago
+    given-names: Kosuke
+  - family-names: Ha
+    given-names: David
+institution:
+  name: "Sakana AI"
+date-released: 2025-06-06
+url: "https://pub.sakana.ai/edinet-bench"
+repository-code: "https://github.com/SakanaAI/edinet-bench"
+keywords:
+  - "financial analysis"
+  - "large language models"
+  - "benchmark"
+  - "Japanese"
+  - "EDINET"
+license: Apache-2.0


### PR DESCRIPTION
## Summary
This PR adds a CITATION.cff file to enable GitHub's built-in citation feature, making it easier for users to properly cite EDINET-Bench in their research and projects.



<img width="534" alt="Screenshot 2025-06-10 at 8 18 13" src="https://github.com/user-attachments/assets/07044305-2516-4c45-a68e-4e88bb06f607" />


## Changes

1. Added CITATION.cff file to the repository root
2. Configured citation metadata to match the existing BibTeX format in the README

## Benefits

1. Easy citation: Users can now click "Cite this repository" on GitHub to get properly formatted citations
2. Multiple formats: GitHub automatically generates both APA and BibTeX formats
3. Consistency: Citation information matches the official BibTeX format already provided in the repository

## Technical Details

1. Uses Citation File Format (CFF) version 1.2.0
2. Includes all author information with proper name formatting
3. Configured as type: data in preferred citation to reflect the dataset nature
4. Generates misc BibTeX type with institution field, matching the existing citation format

## Reference
1. https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files